### PR TITLE
[WIP] Implementing `Query#timestamps`

### DIFF
--- a/app/models/journal/timestamps.rb
+++ b/app/models/journal/timestamps.rb
@@ -50,7 +50,8 @@ module Journal::Timestamps
     # a journable at a given timestamp.
     #
     def at_timestamp(timestamp)
-      raise ArgumentError, "Expected timestamp to be an ActiveSupport::TimeWithZone or DateTime" unless timestamp.kind_of? ActiveSupport::TimeWithZone or timestamp.kind_of? DateTime
+      raise ArgumentError, "Expected timestamp to be a Timestamp, an ActiveSupport::TimeWithZone, or a DateTime" unless timestamp.kind_of? Timestamp or timestamp.kind_of? ActiveSupport::TimeWithZone or timestamp.kind_of? DateTime
+      timestamp = timestamp.to_time if timestamp.kind_of? Timestamp
       timestamp = timestamp.in_time_zone if timestamp.kind_of? DateTime
 
       where(id:

--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -28,6 +28,7 @@
 
 class Query < ApplicationRecord
   include Timelines
+  include Timestamps
   include Highlighting
   include ManualSorting
   include Queries::Filters::AvailableFilters

--- a/app/models/query/results.rb
+++ b/app/models/query/results.rb
@@ -44,11 +44,14 @@ class ::Query::Results
 
   # Returns the work packages adhering to the filters and ordered by the provided criteria (grouping and sorting)
   def work_packages
-    WorkPackage
+    work_package_scope
       .where(id: work_package_ids)
+      .includes(all_includes)
+      .joins(all_joins)
       .order(order_option)
       .references(:projects)
       .order(sort_criteria_array)
+      #.at_timestamp(query.timestamps.last)
   end
 
   def work_package_ids

--- a/app/models/query/timestamps.rb
+++ b/app/models/query/timestamps.rb
@@ -1,0 +1,56 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2022 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+#
+module Query::Timestamps
+  extend ActiveSupport::Concern
+
+  included do
+    serialize :timestamps, Array
+    
+    # Returns the timestamps the query should be evaluated at.
+    #
+    # In the database, the timestamps are stored as ISO8601 strings.
+    # This method returns the timestamps as array of `Timestamp` objects.
+    #
+    # Timestamps can be absolute (e.g. a certain date and time) or relative
+    # (e.g. three weeks ago). To convert a timestamp to a absolute time,
+    # call `timestamp.to_time`.
+    #
+    def timestamps
+      timestamps = super.collect { |timestamp_string|
+        Timestamp.new(timestamp_string)
+      }
+      return timestamps.any? ? timestamps : [Timestamp.now]
+    end
+    
+    def timestamps=(array)
+      super(array.collect { |element| element.respond_to?(:iso8601) ? element.iso8601 : element })
+    end
+  end
+  
+end

--- a/app/models/timestamp.rb
+++ b/app/models/timestamp.rb
@@ -1,0 +1,75 @@
+class Timestamp
+  
+  def initialize(arg = Timestamp.now.to_s)
+    if arg.kind_of? String
+      @timestamp_iso8601_string = arg
+    elsif arg.respond_to? :iso8601
+      @timestamp_iso8601_string = arg.iso8601
+    else
+      raise Timestamp::Exception, "Argument type not supported. Please provide a String or anything that responds to :iso8601, e.g. a Time."
+    end
+  end
+  
+  def self.parse(iso8601_string)
+    if iso8601_string.start_with? "P" # ISO8601 "Period"
+      ActiveSupport::Duration.parse(iso8601_string)
+    else
+      Time.parse(iso8601_string)
+    end
+    Timestamp.new(iso8601_string)
+  end
+  
+  def self.now
+    self.new(ActiveSupport::Duration.build(0).iso8601)
+  end
+  
+  def relative?
+    to_s.first == "P" # ISO8601 "Period"
+  end
+  
+  def to_s
+    iso8601
+  end
+  
+  def to_str
+    to_s
+  end
+  
+  def iso8601
+    @timestamp_iso8601_string.to_s
+  end
+  
+  def inspect
+    "#<Timestamp \"#{to_s}\">"
+  end
+  
+  def to_time
+    if relative?
+      Time.zone.now - to_duration * (to_duration.to_i.positive? ? 1 : -1)
+    else
+      Time.parse(self)
+    end
+  end
+  
+  def to_duration
+    if relative?
+      ActiveSupport::Duration.parse(self)
+    else
+      raise Timestamp::Exception, "This timestamp is absolute and cannot be represented as ActiveSupport::Duration."
+    end
+  end
+  
+  def as_json
+    to_s
+  end
+  
+  def to_json
+    to_s
+  end
+  
+  def ==(other_timestamp)
+    self.iso8601 == other_timestamp.iso8601
+  end
+  
+  class Exception < StandardError; end
+end

--- a/db/migrate/20221029194419_add_timestamps_to_queries.rb
+++ b/db/migrate/20221029194419_add_timestamps_to_queries.rb
@@ -1,0 +1,5 @@
+class AddTimestampsToQueries < ActiveRecord::Migration[7.0]
+  def change
+    add_column :queries, :timestamps, :string
+  end
+end

--- a/spec/models/query/results_filter_on_historic_data_spec.rb
+++ b/spec/models/query/results_filter_on_historic_data_spec.rb
@@ -1,0 +1,152 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2022 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require 'spec_helper'
+
+describe ::Query::Results, 'Filter on historic data', type: :model, with_mail: false do
+  let(:historic_time) { "2022-08-01".to_datetime }
+  let(:pre_historic_time) { historic_time - 1.day }
+  let(:recent_time) { 1.hour.ago }
+  let!(:work_package) do
+    new_work_package = create :work_package, description: "This is the original description of the work package", project: project_1
+    new_work_package.update_columns created_at: historic_time
+    new_work_package.journals.first.update_columns created_at: historic_time, updated_at: historic_time
+    new_work_package.reload
+    new_work_package.update description: "This is the current description of the work package", updated_at: recent_time
+    new_work_package.journals.last.update_columns created_at: recent_time, updated_at: recent_time
+    new_work_package.reload
+    new_work_package
+  end
+
+  let(:project_1) { create :project }
+  let(:user_1) do
+    create(:user,
+           firstname: 'user',
+           lastname: '1',
+           member_in_project: project_1,
+           member_with_permissions: [:view_work_packages])
+  end
+  
+  
+  describe "[prelims]" do
+    specify "the work package has a journal entry with the historic description" do
+      expect(work_package.journals.count).to eq 2
+      expect(work_package.journals.first.data.description).to eq "This is the original description of the work package"
+    end
+    
+    specify "the work package has its current description" do
+      expect(work_package.description).to eq "This is the current description of the work package"
+    end
+  end
+  
+  describe "#work_packages" do
+    let(:query) do
+      login_as(user_1)
+      build(:query, user: user_1, project: nil).tap do |query|
+        query.filters.clear
+        query.add_filter 'description', '~', search_term
+      end
+    end
+    let(:results) { query.results }
+    subject { results.work_packages }
+  
+    describe "filter for description containing 'current'" do
+      let(:search_term) { 'current' }
+      it "includes the work package matching today" do
+        expect(subject).to include work_package
+      end
+    end
+
+    describe "filter for description containing 'original'" do
+      let(:search_term) { 'original' }
+      it "does not include the work package matching only in the past" do
+        expect(subject).not_to include work_package
+      end
+    end
+    
+    describe "when searching current and historic work packages" do
+      before { query.timestamps = [historic_time, Time.zone.now] }
+
+      describe "filter for description containing 'current'" do
+        let(:search_term) { 'current' }
+        it "includes the work package matching today" do
+          expect(subject).to include work_package
+        end
+      end
+
+      describe "filter for description containing 'original'" do
+        let(:search_term) { 'original' }
+        it "includes the work package matching in the past" do
+          expect(subject).to include work_package
+        end
+      end
+    end
+    
+    describe "when searching only historic work packages" do
+      before { query.timestamps = [historic_time] }
+
+      describe "filter for description containing 'current'" do
+        let(:search_term) { 'current' }
+        it "does not include the work package matching only in the past" do
+          expect(subject).not_to include work_package
+        end
+      end
+
+      describe "filter for description containing 'original'" do
+        let(:search_term) { 'original' }
+        
+        it "includes the work package matching in the past" do
+          expect(subject).to include work_package
+        end
+        
+        it "returns the work packages in their historic state" do
+          expect(subject.first.description).to eq "This is the original description of the work package"
+        end
+      end
+    end
+    
+    describe "when searching only pre-historic work packages (i.e. when the work package does not exist yet)" do
+      before { query.timestamps = [pre_historic_time] }
+
+      describe "filter for description containing 'current'" do
+        let(:search_term) { 'current' }
+        it "does not include the work package matching only in the past" do
+          expect(subject).not_to include work_package
+        end
+      end
+
+      describe "filter for description containing 'original'" do
+        let(:search_term) { 'original' }
+        it "does not include the work package because it does not exist yet at that time" do
+          expect(subject).not_to include work_package
+        end
+      end
+    end
+
+  end
+end

--- a/spec/models/query/results_spec.rb
+++ b/spec/models/query/results_spec.rb
@@ -703,6 +703,7 @@ describe ::Query::Results, type: :model, with_mail: false do
       let(:work_package2) { create(:work_package, project: project2) }
       let(:work_package3) { create(:work_package, project: project3) }
 
+      before { [work_package1, work_package2, work_package3] }
       before { login_as(user1) }
 
       context 'when ascending' do
@@ -739,6 +740,7 @@ describe ::Query::Results, type: :model, with_mail: false do
       let(:work_package2) { create(:work_package, project: project1, category: category2) }
       let(:work_package3) { create(:work_package, project: project1, category: category3) }
 
+      before { [work_package1, work_package2, work_package3] }
       before { login_as(user1) }
 
       context 'when ascending' do
@@ -775,15 +777,13 @@ describe ::Query::Results, type: :model, with_mail: false do
       let(:work_package2) { create(:work_package, project: project1, subject: 'WorkPackage b') }
       let(:work_package3) { create(:work_package, project: project1, subject: 'WorkPackage C') }
 
+      before { [work_package1, work_package2, work_package3] }
       before { login_as(user1) }
 
       context 'when ascending' do
         let(:sort_by) { [['subject', 'asc']] }
 
         it 'sorts case insensitive' do
-          query_results.work_packages
-          [work_package1, work_package2, work_package3]
-
           expect(query_results.work_packages)
             .to match [work_package1, work_package2, work_package3]
         end
@@ -811,6 +811,7 @@ describe ::Query::Results, type: :model, with_mail: false do
       let(:work_package2) { create(:work_package, project: project1, due_date: 2.days.ago) }
       let(:work_package3) { create(:work_package, project: project1, due_date: 1.day.ago) }
 
+      before { [work_package1, work_package2, work_package3] }
       before { login_as(user1) }
 
       context 'when ascending' do

--- a/spec/models/query/timestamps_spec.rb
+++ b/spec/models/query/timestamps_spec.rb
@@ -1,0 +1,99 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2022 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require 'spec_helper'
+
+describe Query::Timestamps, type: :model do
+  
+  describe "#timestamps" do
+    subject { query.timestamps }
+    describe "after setting timestamps to an array of ISO8601 Strings" do
+      let(:query) { Query.new }
+      before { query.timestamps = ["P-50Y", "2022-10-29T23:01:23Z"] }
+      
+      it "returns an Array of Timestamp objects" do
+        expect(subject).to be_kind_of Array
+        expect(subject.map(&:class).uniq).to eq [Timestamp]
+      end
+      
+      it "remembers which timestamp encodes a relative time" do
+        expect(subject.first.relative?).to eq true
+        expect(subject.last.relative?).to eq false
+      end
+    end
+    
+    describe "after setting timestamps to an array of Times" do
+      let(:query) { Query.new }
+      before { query.timestamps = [50.years.ago, Time.zone.now] }
+
+      it "returns an Array of Timestamp objects" do
+        expect(subject).to be_kind_of Array
+        expect(subject.map(&:class).uniq).to eq [Timestamp]
+      end
+    end
+    
+    describe "when not present" do
+      let(:query) { Query.new }
+      before { query.timestamps = [] }
+      
+      it "still returns the timestamp corresponding to the present time" do
+        expect(subject).to eq [Timestamp.now]
+      end
+    end
+    
+    describe "[persistence] when saving timestamps to a record" do
+      let(:query) { create :query }
+      before do
+        query.timestamps = ["P-50Y", "2022-10-29T23:01:23Z"]
+        query.save!
+      end
+      
+      describe "after reloading the record from the database" do
+        let(:reloaded_query) { Query.find(query.id) }
+        subject { reloaded_query.timestamps }
+        
+        it "returns an Array of Timestamp objects" do
+          expect(subject).to be_kind_of Array
+          expect(subject.map(&:class).uniq).to eq [Timestamp]
+        end
+      
+        it "remembers which timestamp encodes a relative time" do
+          expect(subject.first.relative?).to eq true
+          expect(subject.last.relative?).to eq false
+        end
+        
+        it "remembers the timestamp values" do
+          expect(subject.first.iso8601).to eq "P-50Y"
+          expect(subject.last.iso8601).to eq "2022-10-29T23:01:23Z"
+        end
+      end
+      
+    end
+  end
+  
+end

--- a/spec/models/timestamp_spec.rb
+++ b/spec/models/timestamp_spec.rb
@@ -1,0 +1,256 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2022 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require 'spec_helper'
+
+describe Timestamp, type: :model do
+  
+  describe ".new" do
+    describe "when calling without argument" do
+      subject { Timestamp.new }
+      
+      it "returns Timestamp.now" do
+        expect(subject.to_s).to eq Timestamp.now.to_s
+      end
+    end
+    
+    describe "when providing an ISO8601 String" do
+      subject { Timestamp.new("PT10S") }
+      
+      it "returns a Timestamp" do
+        expect(subject).to be_kind_of Timestamp
+      end
+      
+      specify "the argument is retrievable via to_s" do
+        expect(subject.to_s).to eq "PT10S"
+      end
+    end
+      
+    describe "when providing a Time" do
+      let(:time) { Time.zone.now }
+      subject { Timestamp.new(time) }
+      
+      it "returns an absolute Timestamp representing that time (up to full seconds)" do
+        expect(subject).to be_kind_of Timestamp
+        expect(subject.relative?).to eq false
+        expect(subject.to_time).to eq Time.at(time.to_i)
+      end
+    end
+    
+    describe "when providing a non-supported object" do
+      subject { Timestamp.new(:foo) }
+      
+      it "raises an error" do
+        expect { subject }.to raise_error Timestamp::Exception
+      end
+    end
+  end
+  
+  describe ".now" do
+    subject { Timestamp.now }
+    
+    it "returns a Timestamp" do
+      expect(subject).to be_kind_of Timestamp
+    end
+    
+    it "returns a relative timestamp" do
+      expect(subject.relative?).to eq true
+    end
+    
+    it "corresponds to a duration of 0 seconds (ago)" do
+      expect(subject.to_duration).to eq ActiveSupport::Duration.build(0)
+    end
+  end
+  
+  describe ".parse" do
+    describe "when providing a valid ISO8601 duration" do
+      subject { Timestamp.parse("PT10S") }
+      
+      it "returns a Timestamp representing a time ago that duration" do
+        expect(subject).to be_kind_of Timestamp
+        expect(subject.to_s).to eq "PT10S"
+        expect(subject.to_duration).to eq ActiveSupport::Duration.build(10)
+        expect(subject.relative?).to eq true
+      end
+    end
+    
+    describe "when providing a valid ISO8601 time" do
+      subject { Timestamp.parse("2022-10-29T21:55:58Z") }
+      
+      it "returns a Timestamp representing that absolute time" do
+        expect(subject).to be_kind_of Timestamp
+        expect(subject.to_s).to eq "2022-10-29T21:55:58Z"
+        expect(subject.to_time).to eq Time.parse("2022-10-29T21:55:58Z")
+        expect(subject.relative?).to eq false
+      end
+    end
+    
+    describe "when providing something invalid" do
+      subject { Timestamp.parse("foo") }
+      
+      it "raises an error" do
+        expect { subject }.to raise_error ArgumentError
+      end
+    end
+  end
+  
+  describe "#relative?" do
+    subject { timestamp.relative?}
+    describe "for a timestamp representing an absolute time" do
+      let(:timestamp) { Timestamp.new(Time.zone.now - 1.year) }
+      it "returns false" do
+        expect(subject).to eq false
+      end
+    end
+    describe "for a timestamp representing a point in time relative to now" do
+      let(:timestamp) { Timestamp.new("PT10S") }
+      it "returns true" do
+        expect(subject).to eq true
+      end
+    end
+  end
+  
+  describe "#iso8601" do
+    subject { timestamp.iso8601 }
+    describe "for a timestamp representing an absolute time" do
+      let(:timestamp) { Timestamp.new(Time.zone.now - 1.year) }
+      it "returns an ISO8601 String representing that time" do
+        expect(subject).to eq timestamp.to_time.iso8601
+      end
+    end
+    describe "for a timestamp representing a point in time relative to now" do
+      let(:timestamp) { Timestamp.new("PT10S") }
+      it "returns an ISO8601 String representing the duration between that time and now" do
+        expect(subject).to eq "PT10S"
+        expect(subject).to eq ActiveSupport::Duration.build(10).iso8601
+      end
+    end
+  end
+
+  describe "#to_s" do
+    subject { timestamp.to_s }
+    describe "for a timestamp representing an absolute time" do
+      let(:timestamp) { Timestamp.new(Time.zone.now - 1.year) }
+      it "returns an ISO8601 String representing that time" do
+        expect(subject).to eq timestamp.to_time.iso8601
+      end
+    end
+    describe "for a timestamp representing a point in time relative to now" do
+      let(:timestamp) { Timestamp.new("PT10S") }
+      it "returns an ISO8601 String representing the duration between that time and now" do
+        expect(subject).to eq "PT10S"
+        expect(subject).to eq ActiveSupport::Duration.build(10).iso8601
+      end
+    end
+  end
+
+  describe "#to_json" do
+    subject { timestamp.to_json }
+    describe "for a timestamp representing an absolute time" do
+      let(:timestamp) { Timestamp.new(Time.zone.now - 1.year) }
+      it "returns an ISO8601 String representing that time" do
+        expect(subject).to eq timestamp.to_time.iso8601
+      end
+    end
+    describe "for a timestamp representing a point in time relative to now" do
+      let(:timestamp) { Timestamp.new("PT10S") }
+      it "returns an ISO8601 String representing the duration between that time and now" do
+        expect(subject).to eq "PT10S"
+        expect(subject).to eq ActiveSupport::Duration.build(10).iso8601
+      end
+    end
+  end
+  
+  describe "#to_time" do
+    subject { timestamp.to_time }
+    describe "for a timestamp representing an absolute time" do
+      let(:time) { Time.zone.now - 1.year }
+      let(:timestamp) { Timestamp.new(time) }
+      it "returns a Time representing that time (up to full seconds)" do
+        expect(subject).to be_kind_of Time
+        expect(subject).to eq Time.at(time.to_i)
+      end
+    end
+    describe "for a timestamp representing a point in time relative to now" do
+      Timecop.freeze do
+        let(:timestamp) { Timestamp.new("PT10S") }
+        it "returns a Time converting the relative time to an absolute time (relative to now at evaluation time)" do
+          expect(subject).to be_kind_of Time
+          expect(Time.at(subject.to_i)).to eq Time.at(10.seconds.ago.to_i)
+        end
+      end
+    end
+    describe "for a timestamp representing a point in time relative to now with negative duration" do
+      Timecop.freeze do
+        let(:timestamp) { Timestamp.new("PT-10S") }
+        it "returns a Time converting the relative time to an absolute time (relative to now at evaluation time)" do
+          expect(subject).to be_kind_of Time
+          expect(Time.at(subject.to_i)).to eq Time.at(10.seconds.ago.to_i)
+        end
+      end
+    end
+  end
+  
+  describe "#to_duration" do
+    subject { timestamp.to_duration }
+    describe "for a timestamp representing an absolute time" do
+      let(:time) { Time.zone.now - 1.year }
+      let(:timestamp) { Timestamp.new(time) }
+      it "raises an error because the absolute time does not change when the current time progresses and therefore cannot be represented as constant duration" do
+        expect { subject }.to raise_error Timestamp::Exception
+      end
+    end
+    describe "for a timestamp representing a point in time relative to now" do
+      Timecop.freeze do
+        let(:timestamp) { Timestamp.new("PT10S") }
+        it "returns an ActiveSupport::Duration corresponding to the duration between the timestamp and now" do
+          expect(subject).to be_kind_of ActiveSupport::Duration
+          expect(subject).to eq ActiveSupport::Duration.build(10)
+        end
+      end
+    end
+  end
+  
+  describe "passing a Timestamp to a where clause" do
+    subject { Query.where("updated_at < ?", timestamp) }
+    let(:timestamp) { Timestamp.new("PT10S") }
+    
+    it "raises an error because the query interface requires a Time type" do
+      expect { subject }.to raise_error TypeError
+    end
+    
+    describe "when converting the timestamp to_time" do
+      subject { Query.where("updated_at < ?", timestamp.to_time) }
+      
+      it "raises no error" do
+        expect { subject }.not_to raise_error TypeError
+      end
+    end
+  end
+  
+end


### PR DESCRIPTION
This pull request has been moved to the upstream repository: https://github.com/opf/openproject/pull/11678

---

In the context of the [baseline-comparison feature](https://community.openproject.org/projects/openproject/work_packages/26448), this pull request enables the `Query` model to query work packages at different points in time.

### Timestamps

For the baseline-comparison feature we need to query historic data of work packages. In addition to the current state of the work packages (today), we can ask for the state of work packages at other points in time (**timestamps**).

The timestamps can be specified

- **absolute**, e.g. "2022-08-01", or 
- **relative**, e.g. "1 month ago".

This pull request implements an abstraction class `Timestamp` that can be initialised with [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) strings.

```ruby
absolute_timestamp = Timestamp.parse("2022-10-29T23:01:23Z")
relative_timestamp = Timestamp.parse("P-5Y")  # 5 years ago
```

The timestamps can be converted to regular times, which are always absolute then:

```ruby
relative_timestamp.to_time
```

The timestamps can be passed to work package queries:

```ruby
WorkPackage.at_timestamp(relative_timestamp).where(...)
```

### Querying without timestamps

This is how one would search work packages with a description containing the expression "foo", which also works without this pull request:

```ruby
query = Query.new
query.add_filter 'description', '~', "foo"
query.results.work_packages
```

This searches for work packages that have the term "foo" in their description in their most current states, i.e. **today**.

### Adding timestamps to a Query

For the baseline-comparison feature, we would like to also search historic data, i.e. find those work packages that

- have the term "foo" in their description today **or**
- had the term "foo" in their description at an earlier point in time (baseline date).

```ruby
today = Time.zone.now
baseline_date = 1.year.ago

query = Query.new
query.add_filter 'description', '~', "foo"
query.timestamps = [baseline_date, today]
query.results.work_packages
```

This returns the work packages in their today's state.

In order to get the historic state of a specific work package at the `baseline_date`, call:

```ruby
work_package = query.results.work_packages.first
work_package.at_timestamp(baseline_date)
```

In order to get the historic state of all the work packages in the query result at the `baseline_date`, call:

```ruby
work_packages = query.results.work_packages
work_packages.at_timestamp(baseline_date)
```

### Query only for historic data

If you are not interested in the work pacakges as they are today, but only in their historic state, configure the query like this:

```ruby
historic_date = 1.year.ago

query = Query.new
query.add_filter 'description', '~', "foo"
query.timestamps = [historic_date]
query.results.work_packages
```

This returns the the work packages in their states at the `historic_date`. 

### Work to be done

- [x] Implement `Timestamp` model as abstraction for absolute and relative timestamps ➝ https://github.com/fiedl/openproject/pull/2/commits/49d14e6631a43fcb15e9bd823db894e8004eea21
- [x] Add serialized `timestamps` attribute to the `Query` model ➝ https://github.com/fiedl/openproject/pull/2/commits/49d14e6631a43fcb15e9bd823db894e8004eea21
- [x] Query results: Search work packages at all `timestamps` ➝ https://github.com/fiedl/openproject/pull/2/commits/2f51f91f23f78d0130bd952e2e24d5f53f07d89e
- [ ] Make sure that the previous model specs are still green
- [ ] Handle case where the last timestamp is not "now"
- [ ] Use sub queries rather than storing the ids

### See also

- https://github.com/opf/openproject/pull/11243
- **Epic**: https://community.openproject.org/projects/openproject/work_packages/26448